### PR TITLE
Update PySide2 to PySide6

### DIFF
--- a/FlashGBX/DataTransfer.py
+++ b/FlashGBX/DataTransfer.py
@@ -3,16 +3,16 @@
 # Author: Lesserkuma (github.com/lesserkuma)
 
 import traceback
-import PySide2
+import PySide6
 
-class DataTransfer(PySide2.QtCore.QThread):
+class DataTransfer(PySide6.QtCore.QThread):
 	CONFIG = None
 	FINISHED = False
 	
-	updateProgress = PySide2.QtCore.Signal(object)
+	updateProgress = PySide6.QtCore.Signal(object)
 
 	def __init__(self, config=None):
-		PySide2.QtCore.QThread.__init__(self)
+		PySide6.QtCore.QThread.__init__(self)
 		if config is not None:
 			self.CONFIG = config
 		self.FINISHED = False

--- a/FlashGBX/FlashGBX.py
+++ b/FlashGBX/FlashGBX.py
@@ -162,8 +162,7 @@ def main(portableMode=False):
 		try:
 			from . import FlashGBX_GUI
 			app = FlashGBX_GUI.FlashGBX_GUI(args)
-		except ModuleNotFoundError as e:
-			print(e)
+		except ModuleNotFoundError:
 			app = None
 		except:
 			exc = traceback.format_exc()

--- a/FlashGBX/FlashGBX.py
+++ b/FlashGBX/FlashGBX.py
@@ -77,7 +77,6 @@ def LoadConfig(args):
 class ArgParseCustomFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter): pass
 def main(portableMode=False):
 	if platform.system() == "Windows": os.system("color")
-	os.environ['QT_MAC_WANTS_LAYER'] = '1'
 	
 	print("{:s} {:s} by Lesserkuma".format(Util.APPNAME, Util.VERSION))
 	print("https://github.com/lesserkuma/FlashGBX")
@@ -89,7 +88,7 @@ def main(portableMode=False):
 		app_path = os.path.dirname(os.path.abspath(__file__))
 	
 	try:
-		from PySide2 import QtCore
+		from PySide6 import QtCore
 		cp = { "subdir":app_path + "/config", "appdata":QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.AppConfigLocation) + '/FlashGBX' }
 	except:
 		cp = { "subdir":app_path + "/config", "appdata":os.path.expanduser('~') + '/FlashGBX' }
@@ -163,7 +162,8 @@ def main(portableMode=False):
 		try:
 			from . import FlashGBX_GUI
 			app = FlashGBX_GUI.FlashGBX_GUI(args)
-		except ModuleNotFoundError:
+		except ModuleNotFoundError as e:
+			print(e)
 			app = None
 		except:
 			exc = traceback.format_exc()

--- a/FlashGBX/FlashGBX_GUI.py
+++ b/FlashGBX/FlashGBX_GUI.py
@@ -3,7 +3,7 @@
 # Author: Lesserkuma (github.com/lesserkuma)
 
 import sys, os, time, datetime, re, json, platform, subprocess, requests, webbrowser, pkg_resources, struct, math
-from PySide2 import QtCore, QtWidgets, QtGui
+from PySide6 import QtCore, QtWidgets, QtGui
 from .RomFileDMG import RomFileDMG
 from .RomFileAGB import RomFileAGB
 from .PocketCameraWindow import PocketCameraWindow
@@ -2222,7 +2222,7 @@ class FlashGBX_GUI(QtWidgets.QWidget):
 		
 		# Taskbar Progress on Windows only
 		try:
-			from PySide2.QtWinExtras import QWinTaskbarButton, QtWin
+			from PySide6.QtWinExtras import QWinTaskbarButton, QtWin
 			myappid = 'lesserkuma.flashgbx'
 			QtWin.setCurrentProcessExplicitAppUserModelID(myappid)
 			taskbar_button = QWinTaskbarButton()
@@ -2233,7 +2233,7 @@ class FlashGBX_GUI(QtWidgets.QWidget):
 		except ImportError:
 			pass
 		
-		qt_app.exec_()
+		qt_app.exec()
 
 qt_app = QtWidgets.QApplication(sys.argv)
 qt_app.setApplicationName(APPNAME)

--- a/FlashGBX/PocketCameraWindow.py
+++ b/FlashGBX/PocketCameraWindow.py
@@ -5,7 +5,7 @@
 import functools, os, json, platform, shutil, hashlib
 from PIL.ImageQt import ImageQt
 from PIL import Image, ImageDraw
-from PySide2 import QtCore, QtWidgets, QtGui
+from PySide6 import QtCore, QtWidgets, QtGui
 from .PocketCamera import PocketCamera
 
 class PocketCameraWindow(QtWidgets.QDialog):

--- a/FlashGBX/fw_GBxCartRW_v1_3.py
+++ b/FlashGBX/fw_GBxCartRW_v1_3.py
@@ -3,7 +3,7 @@
 # Author: Lesserkuma (github.com/lesserkuma)
 
 import zipfile, os, serial, struct, time, re, math, platform
-from PySide2 import QtCore, QtWidgets, QtGui
+from PySide6 import QtCore, QtWidgets, QtGui
 from . import Util
 
 class FirmwareUpdaterWindow(QtWidgets.QDialog):

--- a/FlashGBX/fw_GBxCartRW_v1_4.py
+++ b/FlashGBX/fw_GBxCartRW_v1_4.py
@@ -3,7 +3,7 @@
 # Author: Lesserkuma (github.com/lesserkuma)
 
 import zipfile, serial, struct, time, random, hashlib, datetime
-from PySide2 import QtCore, QtWidgets, QtGui
+from PySide6 import QtCore, QtWidgets, QtGui
 try:
 	from . import Util
 except ImportError:

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ Available in the GitHub [Releases](https://github.com/lesserkuma/FlashGBX/releas
 
 1. Download and install [Python](https://www.python.org/downloads/) (version 3.7 or higher)
 2. Open a Terminal or Command Prompt window
-3. If your Python version is 3.10 or newer, first run this command:<br>`pip3 install --ignore-requires-python -U PySide2`
+3. If your Python version is 3.10 or newer, first run this command:<br>`pip3 install --ignore-requires-python -U PySide6`
 4. Install or upgrade FlashGBX with this command:<br>`pip3 install -U FlashGBX`
-* If installation fails and you see an error about a conflict involving PySide2, try these commands instead:<br>`pip3 install pyserial Pillow setuptools requests python-dateutil`<br>`pip3 install --no-deps -U FlashGBX`
+* If installation fails and you see an error about a conflict involving PySide6, try these commands instead:<br>`pip3 install pyserial Pillow setuptools requests python-dateutil`<br>`pip3 install --no-deps -U FlashGBX`
 
 * Pre-made Linux packages and instructions for select distributions are available [here](https://github.com/JJ-Fox/FlashGBX-Linux-builds/releases/latest).
 
-*FlashGBX should work on pretty much any operating system that supports Qt-GUI applications built using [Python](https://www.python.org/downloads/) with [PySide2](https://pypi.org/project/PySide2/), [pyserial](https://pypi.org/project/pyserial/), [Pillow](https://pypi.org/project/Pillow/), [setuptools](https://pypi.org/project/setuptools/), [requests](https://pypi.org/project/requests/) and [python-dateutil](https://pypi.org/project/python-dateutil/) packages.*
+*FlashGBX should work on pretty much any operating system that supports Qt-GUI applications built using [Python](https://www.python.org/downloads/) with [PySide6](https://pypi.org/project/PySide6/), [pyserial](https://pypi.org/project/pyserial/), [Pillow](https://pypi.org/project/Pillow/), [setuptools](https://pypi.org/project/setuptools/), [requests](https://pypi.org/project/requests/) and [python-dateutil](https://pypi.org/project/python-dateutil/) packages.*
 
 #### Running
 Use this command in a Terminal or Command Prompt window to launch the installed FlashGBX application:
@@ -255,7 +255,7 @@ Many different reproduction cartridges share their flash chip command set, so ev
 
 * If you’re using macOS version 10.13 or older, there may be no driver for the *insideGadgets GBxCart RW* device installed on your system. You can either upgrade your macOS version to 10.14+ or manually install a driver which is available [here](https://github.com/adrianmihalko/ch340g-ch34g-ch34x-mac-os-x-driver).
 
-* If you use Python 3.10+ and see the error `Type Error: 'PySide2.QtCore.Qt.WindowType' object cannot be interpreted as an integer` or can only use CLI mode, try to install or update the PySide2 package by running `pip3 install -U PySide2 --ignore-requires-python` or try the older [Python version 3.9.9](https://www.python.org/downloads/release/python-399/).
+* If you use Python 3.10+ and see the error `Type Error: 'PySide6.QtCore.Qt.WindowType' object cannot be interpreted as an integer` or can only use CLI mode, try to install or update the PySide6 package by running `pip3 install -U PySide6 --ignore-requires-python` or try the older [Python version 3.9.9](https://www.python.org/downloads/release/python-399/).
 
 * If your Game Boy Camera cartridge is not reading, make sure it’s connected the correct way around; screws go up.
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
 	description="Reads and writes Game Boy and Game Boy Advance cartridge data. Supported hardware: GBxCart RW v1.3 and v1.4 by insideGadgets.",
 	url="https://github.com/lesserkuma/FlashGBX",
 	packages=setuptools.find_packages(),
-	install_requires=['PySide2', 'pyserial', 'Pillow', 'setuptools', 'requests', 'python-dateutil'],
+	install_requires=['PySide6', 'pyserial', 'Pillow', 'setuptools', 'requests', 'python-dateutil'],
 	include_package_data=True,
 	classifiers=[
 		"Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Hello, this change upgrades PySide2 to PySide6. I'm on an M1 Mac and could never get PySide2 to work. It also seems to be in maintenance mode. So a migration to PySide6 will probably be needed at some point. That said, this was a relatively straight forward update so I feel like I'm probably missing something since I would imagine a transition would have been done long ago. 

Regardless, the FlashGBX GUI is working for me now so if anyone is having difficulties with PySide2 maybe give PySide6 a shot with these updates.