### PR TITLE
Require PySide2>=5.14 during installation, avoid incompatible PySide2 at runtime

### DIFF
--- a/FlashGBX/pyside.py
+++ b/FlashGBX/pyside.py
@@ -9,6 +9,10 @@ from .Util import dprint
 
 try:
 	import PySide2
+	# PySide2>=5.14 is required
+	major, minor, *_ = PySide2.__version_info__
+	if (major, minor) < (5, 14):
+		raise ImportError('Requires PySide2>=5.14', name=PySide2.__package__, path=PySide2.__path__)
 	psversion = 2
 except ImportError as err:
 	try:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
 	packages=setuptools.find_packages(),
 	install_requires=['pyserial>=3.5', 'Pillow', 'setuptools', 'requests', 'python-dateutil'],
 	extras_require={
-		"qt5":["PySide2"],
+		"qt5":["PySide2>=15.4"],
 		"qt6":["PySide6"]
 	},
 	include_package_data=True,


### PR DESCRIPTION
These changes help prevent users from installing incompatible versions of PySide2. If they already have an incompatible version installed, we also don't want to use it at runtime.

A notable feature of this change is that running `pip install 'FlashGBX[qt5]'` should now fail with Python 3.11. Newer, required versions of PySide2 don't support Python 3.11, so pip installs an old, incompatible version. It is better to fail early when running pip than when running FlashGBX.

Finding the minimum version
---
FlashGBX requires PySide2 5.14.0 or newer. This is now expressed in setup.py. Additionally, if an older version of PySide2 is installed, the pyside.py helper script will check its version and avoid using it if it's too old.

I tested manually installing 5.13.2, 5.14.0, 5.15.0, and the latest, 5.15.2.1. With 5.13.2, `python -m FlashGBX` prints:
```
NOTE: GUI mode couldn’t be launched, but the application can be run in CLI mode.
      Optional command line switches are explained above.

Traceback (most recent call last):
  File "~/.venv/lib/python3.11/site-packages/FlashGBX/FlashGBX.py", line 187, in main
    app = FlashGBX_GUI.FlashGBX_GUI(args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.venv/lib/python3.11/site-packages/FlashGBX/FlashGBX_GUI.py", line 44, in __init__
    self.setWindowFlags(self.windowFlags() | QtCore.Qt.MSWindowsFixedSizeDialogHint)
TypeError: 'PySide2.QtCore.Qt.WindowType' object cannot be interpreted as an integer
```

FlashGBX launches successfully with newer versions of PySide2.

Testing
---
Installed PySide2==5.13.2 and PySide6==6.5.0 with pip. Launched FlashGBX to verify that although an incompatible version of PySide2 was available, FlashGBX's new version check made it use PySide6 and launched successfully.