### PR TITLE
Don't set QT_MAC_WANTS_LAYER on modern macOS

### DIFF
--- a/FlashGBX/FlashGBX.py
+++ b/FlashGBX/FlashGBX.py
@@ -78,7 +78,11 @@ def LoadConfig(args):
 class ArgParseCustomFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter): pass
 def main(portableMode=False):
 	if platform.system() == "Windows": os.system("color")
-	os.environ['QT_MAC_WANTS_LAYER'] = '1'
+	if platform.system() == "Darwin":
+		macos_version = tuple(map(int, platform.mac_ver()[0].split('.')))
+		# macOS above Big Sur don't need a compat layer fix in the environment
+		if macos_version < (12, 0):
+			os.environ['QT_MAC_WANTS_LAYER'] = '1'
 	
 	print("{:s} {:s} by Lesserkuma".format(Util.APPNAME, Util.VERSION))
 	print("https://github.com/lesserkuma/FlashGBX")


### PR DESCRIPTION
When you boot up FlashGBX on modern macOS you get this warning in the console

```
qt.qpa.drawing: Layer-backing is always enabled.  QT_MAC_WANTS_LAYER/_q_mac_wantsLayer has no effect.
```

I don't like seeing it, so I researched. It was fixed in Big Sur. I added a guard to the environment variable set to only set it on platforms where it'll potentially have an effect.