### PR TITLE
Automatic task triggering macOS build in remote repo on create release

### DIFF
--- a/.github/workflows/trigger-remote-build-macos.yml
+++ b/.github/workflows/trigger-remote-build-macos.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger Remote Workflow
+      - name: Trigger FlashGBX Remote Build
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: FlashGBX Remote Build
@@ -27,7 +27,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != ''
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger Remote Workflow
+      - name: Trigger FlashGBX Remote Build
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: FlashGBX Remote Build

--- a/.github/workflows/trigger-remote-build-macos.yml
+++ b/.github/workflows/trigger-remote-build-macos.yml
@@ -19,7 +19,7 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: FlashGBX Remote Build
-          token: ${{ secrets.FLASHGBX_MACOS_PAT }}
+          token: ${{ secrets.FLASHGBX_MACOS_TOKEN }}
           repo: Cliffback/FlashGBX-macOS
           inputs: '{"create_release": "true", "latest_version": "${{ github.event.release.tag_name }}"}'
   trigger-manual:
@@ -30,6 +30,6 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: FlashGBX Remote Build
-          token: ${{ secrets.FLASHGBX_MACOS_PAT }}
+          token: ${{ secrets.FLASHGBX_MACOS_TOKEN }}
           repo: Cliffback/FlashGBX-macOS
           inputs: '{"create_release": "true", "latest_version": "${{ github.event.inputs.release_tag }}"}'

--- a/.github/workflows/trigger-remote-build-macos.yml
+++ b/.github/workflows/trigger-remote-build-macos.yml
@@ -21,6 +21,7 @@ jobs:
           workflow: FlashGBX Remote Build
           token: ${{ secrets.FLASHGBX_MACOS_TOKEN }}
           repo: Cliffback/FlashGBX-macOS
+          ref: main
           inputs: '{"create_release": "true", "latest_version": "${{ github.event.release.tag_name }}"}'
   trigger-manual:
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != ''
@@ -32,4 +33,5 @@ jobs:
           workflow: FlashGBX Remote Build
           token: ${{ secrets.FLASHGBX_MACOS_TOKEN }}
           repo: Cliffback/FlashGBX-macOS
+          ref: main
           inputs: '{"create_release": "true", "latest_version": "${{ github.event.inputs.release_tag }}"}'

--- a/.github/workflows/trigger-remote-build-macos.yml
+++ b/.github/workflows/trigger-remote-build-macos.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Trigger Remote Workflow
         uses: benc-uk/workflow-dispatch@v1
         with:
-          workflow: Build FlashGBX Remotely
+          workflow: FlashGBX Remote Build
           token: ${{ secrets.FLASHGBX_MACOS_PAT }}
           repo: Cliffback/FlashGBX-macOS
           inputs: '{"create_release": "true", "latest_version": "${{ github.event.release.tag_name }}"}'
@@ -29,7 +29,7 @@ jobs:
       - name: Trigger Remote Workflow
         uses: benc-uk/workflow-dispatch@v1
         with:
-          workflow: Build FlashGBX Remotely
+          workflow: FlashGBX Remote Build
           token: ${{ secrets.FLASHGBX_MACOS_PAT }}
           repo: Cliffback/FlashGBX-macOS
           inputs: '{"create_release": "true", "latest_version": "${{ github.event.inputs.release_tag }}"}'

--- a/.github/workflows/trigger-remote-build-macos.yml
+++ b/.github/workflows/trigger-remote-build-macos.yml
@@ -30,6 +30,6 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: Build FlashGBX Remotely
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.FLASHGBX_MACOS_PAT }}
           repo: Cliffback/FlashGBX-macOS
           inputs: '{"create_release": "true", "latest_version": "${{ github.event.inputs.release_tag }}"}'

--- a/.github/workflows/trigger-remote-build-macos.yml
+++ b/.github/workflows/trigger-remote-build-macos.yml
@@ -1,0 +1,35 @@
+name: Trigger Remote Build macOS on Release
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag'
+        required: true
+        type: string
+
+jobs:
+  trigger-release:
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Remote Workflow
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: Build FlashGBX Remotely
+          token: ${{ secrets.FLASHGBX_MACOS_PAT }}
+          repo: Cliffback/FlashGBX-macOS
+          inputs: '{"create_release": "true", "latest_version": "${{ github.event.release.tag_name }}"}'
+  trigger-manual:
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Remote Workflow
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: Build FlashGBX Remotely
+          token: ${{ secrets.PAT }}
+          repo: Cliffback/FlashGBX-macOS
+          inputs: '{"create_release": "true", "latest_version": "${{ github.event.inputs.release_tag }}"}'


### PR DESCRIPTION
This workflow triggers the macOS build pipeline in [FlashGBX macOS](https://github.com/Cliffback/FlashGBX-macOS) when a new FlashGBX version is released.

It uses the tag associated with the release as the version number for the compiled mac app, and in the workflow [build_flashgbx_remote.yml](https://github.com/Cliffback/FlashGBX-macOS/blob/main/.github/workflows/build_flashgbx_remote.yml) in the remote repo, the mac app is compiled for both x86_86 and arm64, compressed as a dmg and automatically uploaded as a release, if a version number with the same tag is not already released. 

For this to work, a secret environment variable that gives access to trigger actions in the remote repo is required, and needs to be called FLASHGBX_MACOS_TOKEN. The only thing this does is opening my own repo, Cliffback/FlashGBX-macOS, to accept incoming API request to run pipelines.