### PR TITLE
macos: Don't build app bundle with console enabled

### DIFF
--- a/.github/build/macOS/FlashGBX.spec
+++ b/.github/build/macOS/FlashGBX.spec
@@ -23,7 +23,7 @@ exe = EXE(
 	bootloader_ignore_signals=False,
 	strip=False,
 	upx=True,
-	console=True,
+	console=False,
 	icon=['FlashGBX/res/icon.ico'],
 )
 coll = COLLECT(


### PR DESCRIPTION
Enabling console in pyinstaller will prevent the app from showing its own menubar when in the foreground and also prevents it from appearing in the dock.

If you've got other applications/windows open, this can make it appear hidden in the background & more difficult to make active.