### PR TITLE
Remove dialog that prompts user to update if they disabled update check

### DIFF
--- a/FlashGBX/FlashGBX_GUI.py
+++ b/FlashGBX/FlashGBX_GUI.py
@@ -657,10 +657,6 @@ class FlashGBX_GUI(QtWidgets.QWidget):
 					print("Error: Failed to check for updates (too many API requests). Try again later.")
 				else:
 					print("Error: Failed to check for updates (HTTP status {:d}).".format(ret.status_code))
-		else:
-			update_check = self.SETTINGS.value("UpdateCheck")
-			if update_check is None or (time.time() > (Util.VERSION_TIMESTAMP + (6*30*24*60*60))):
-				QtWidgets.QMessageBox.information(self, "{:s} {:s}".format(APPNAME, VERSION), "Welcome to {:s} {:s} by Lesserkuma!<br><br>".format(APPNAME, VERSION) + "The version update check has been disabled in the options menu and this version is now older than {:d} days. Please regularily check the <a href=\"https://github.com/lesserkuma/FlashGBX/releases/latest\">FlashGBX GitHub page</a> for the latest release notes and updates.".format(int((time.time() - Util.VERSION_TIMESTAMP)/60/60/24)), QtWidgets.QMessageBox.Ok, QtWidgets.QMessageBox.Ok)
 
 	def DisconnectDevice(self):
 		try:


### PR DESCRIPTION

Remove the dialog which prompts the user to update after 180 days if the update check is disabled.

There was some discussion about this in discord. Opening a PR to hopefully improve the chances of it changing in the main distribution of this app since I've seen the popup 3 times today already. 😄

Here are some of the issues with this popup dialog once the 180 criteria is met and it starts appearing:

- Pops up to remind the user every single time the program is started. Forever, with no way to permanently dismiss it.
  - This is particularly a problem when doing a lot of development testing and re-flashing to carts, since FlashGBX sometimes hangs and has to be restarted, leading to seeing this dialog many times per day.
- It pops up to recommend updating... even when there is not even a newer version to update to.

If the user has indicted they don't want to perform version checks by disabling the version check update, that implies they have already signaled willingness to manage that responsibility on their own and don't need (constant) reminders.
