### PR TITLE
Fix exception and bad state if save chip is not detected

### DIFF
--- a/FlashGBX/FlashGBX_GUI.py
+++ b/FlashGBX/FlashGBX_GUI.py
@@ -3048,7 +3048,7 @@ class FlashGBX_GUI(QtWidgets.QWidget):
 							pass
 
 				if save_type == 0:
-					if "Unknown" in save_chip:
+					if save_chip is not None and "Unknown" in save_chip:
 						msg_save_type_s = "<b>Save Type:</b> {:s}<br>".format(save_chip)
 					else:
 						msg_save_type_s = "<b>Save Type:</b> None or unknown (no save data detected)<br>"


### PR DESCRIPTION
I have ModRetro Centipede, with a SST39VF1682 and FM28V020-SG; save_chip is `None` with both a Joey Jr and my Chromatic when detecting.