### PR TITLE
Fix LK_Device::_write retry logic for partial success

### DIFF
--- a/FlashGBX/LK_Device.py
+++ b/FlashGBX/LK_Device.py
@@ -476,8 +476,8 @@ class LK_Device(ABC):
 				hp -= 1
 			if hp > 0:
 				# dprint(f"Recovery: {self.DEVICE.in_waiting} byte(s) in queue! (HP: {hp}/50)")
-				buffer += self.DEVICE.read(count)
-		
+				buffer += self.DEVICE.read(count - len(buffer))
+
 		if len(buffer) != count:
 			tb_stack = traceback.extract_stack()
 			stack = tb_stack[len(tb_stack)-2] # caller only


### PR DESCRIPTION
e.g. if we want two bytes and got one, we want to read one more, not two more