### PR TITLE
Correct voltage for fc_DMG_39VF1681

### DIFF
--- a/FlashGBX/config/fc_DMG_39VF1681.txt
+++ b/FlashGBX/config/fc_DMG_39VF1681.txt
@@ -9,7 +9,7 @@
 		[ 0xBF, 0xC9 ]
 	],
 	"flash_size":0x200000,
-	"voltage":3.3,
+	"voltage":5,
 	"start_addr":0,
 	"first_bank":1,
 	"write_pin":"WR",


### PR DESCRIPTION
ModRetro currently only makes 5V GB/GBC cartridges; no ModRetro Advance yet.

While the chip itself is 3.3V, ModRetro does correct the voltage, usually (always?) with 4x LJ245A

Without this, I get incorrect voltage message boxes in my fork, as the my `hw_Chromatic` is set as DMG-only and
automatic-correct-voltage-for-DMG